### PR TITLE
Narrow down security group rules

### DIFF
--- a/ansible/roles/instances/tasks/create_security_group.yml
+++ b/ansible/roles/instances/tasks/create_security_group.yml
@@ -9,14 +9,56 @@
 - os_security_group_rule:
     security_group: "{{ cluster_name }}"
     protocol: icmp
+    remote_group: "{{ cluster_name }}"
+
+- os_security_group_rule:
+    security_group: "{{ cluster_name }}"
+    protocol: tcp
+    remote_group: "{{ cluster_name }}"
+
+- os_security_group_rule:
+    security_group: "{{ cluster_name }}"
+    protocol: udp
+    remote_group: "{{ cluster_name }}"
+
+- os_security_group_rule:
+    security_group: "{{ cluster_name }}"
+    protocol: tcp
+    port_range_min: 8080
+    port_range_max: 8080
     remote_ip_prefix: 0.0.0.0/0
 
 - os_security_group_rule:
     security_group: "{{ cluster_name }}"
     protocol: tcp
+    port_range_min: 8081
+    port_range_max: 8081
     remote_ip_prefix: 0.0.0.0/0
 
 - os_security_group_rule:
     security_group: "{{ cluster_name }}"
-    protocol: udp
+    protocol: tcp
+    port_range_min: 7077
+    port_range_max: 7077
+    remote_ip_prefix: 0.0.0.0/0
+
+- os_security_group_rule:
+    security_group: "{{ cluster_name }}"
+    protocol: tcp
+    port_range_min: 4040
+    port_range_max: 4040
+    remote_ip_prefix: 0.0.0.0/0
+
+- os_security_group_rule:
+    security_group: "{{ cluster_name }}"
+    protocol: tcp
+    port_range_min: 18080
+    port_range_max: 18080
+    remote_ip_prefix: 0.0.0.0/0
+
+- os_security_group_rule:
+    security_group: "{{ cluster_name }}"
+    protocol: tcp
+    port_range_min: 22
+    port_range_max: 22
     remote_ip_prefix: 0.0.0.0/0


### PR DESCRIPTION
Previous version playbooks had very open firewall rules, making machines vulnerable to various security attacks. Narrowed down security group rules to mitigate attack vector.